### PR TITLE
Set @aylapear as maintainer and code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aylapear

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,8 @@ Package: poispalette
 Title: Poisson Palettes
 Version: 0.0.1
 Authors@R: c(
-    person("Evan", "Amies-Galonski", , "evan@poissonconsulting.ca", c("aut", "cre"), comment = c(ORCID = "0000-0003-1096-2089")),
+    person("Ayla", "Pearson", , "ayla@poissonconsulting.ca", c("aut", "cre"), comment = c(ORCID = "0000-0001-7388-1222")),
+    person("Evan", "Amies-Galonski", , "evan@poissonconsulting.ca", c("aut"), comment = c(ORCID = "0000-0003-1096-2089")),
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", c("aut"), comment = c(ORCID = "0000-0002-7683-4592")),
     person("Poisson Consulting", role = c("cph", "fnd"))
     )


### PR DESCRIPTION
Reassigns the package maintainer from Evan Amies-Galonski (former Poisson team member) to @aylapear (Ayla Pearson):

- `DESCRIPTION`: `cre` role moved to Ayla Pearson; Evan Amies-Galonski retained as `aut`.
- `.github/CODEOWNERS`: assigns @aylapear as code owner for all files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)