### PR TITLE
Update Evan Amies-Galonski email to personal address

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: poispalette
 Title: Poisson Palettes
 Version: 0.0.1
 Authors@R: c(
-    person("Evan", "Amies-Galonski", , "evan@poissonconsulting.ca", c("aut", "cre"), comment = c(ORCID = "0000-0003-1096-2089")),
+    person("Evan", "Amies-Galonski", , "evanamiesgalonski@gmail.com", c("aut", "cre"), comment = c(ORCID = "0000-0003-1096-2089")),
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", c("aut"), comment = c(ORCID = "0000-0002-7683-4592")),
     person("Poisson Consulting", role = c("cph", "fnd"))
     )


### PR DESCRIPTION
Replaces `evan@poissonconsulting.ca` (no longer an active address) with Evan's personal email `evanamiesgalonski@gmail.com` in DESCRIPTION.