### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,5 @@
 ^_pkgdown\.yml$
 ^README\.Rmd$
 ^\.claude$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/internal.R
+++ b/R/internal.R
@@ -1,6 +1,13 @@
-make_palette_subsetter <- function (pal) {
+make_palette_subsetter <- function(pal) {
   function(n) {
-    if(n > length(pal)) err(n, " colours needed, but only ", length(pal), " in chosen colour palette.")
+    if (n > length(pal)) {
+      err(
+        n,
+        " colours needed, but only ",
+        length(pal),
+        " in chosen colour palette."
+      )
+    }
     pal[1:n] |> as.vector()
   }
 }
@@ -12,9 +19,11 @@ vld_hex <- function(x) {
 chk_hex <- function(x) {
   chk_character(x)
   vld <- vld_hex(x)
-  
-  if(!all(vld)) err("Invalid hex codes detected: ", paste(x[!vld], collapse = ", "))
-  
+
+  if (!all(vld)) {
+    err("Invalid hex codes detected: ", paste(x[!vld], collapse = ", "))
+  }
+
   invisible(x)
 }
 
@@ -22,18 +31,20 @@ get_formals <- function(fun, negate = NULL) {
   chk::chk_function(fun)
   formals <- fun |> formals(fun) |> names()
   formals[!formals %in% c("scale_name", negate)]
-
 }
 
 assign_dot_args <- function(dot_args_user, function_def, args_negate) {
-  
   chk::chk_list(dot_args_user)
   chk::chk_atomic(args_negate)
-  
+
   dot_args <- get_formals(function_def, negate = args_negate)
   dot_args <- dot_args[!dot_args %in% names(dot_args_user)]
-  if(is.null(names(dot_args_user))) names(dot_args_user) <- rep("", length(dot_args_user))
-  names(dot_args_user)[names(dot_args_user) == ""] <- dot_args[1:sum(names(dot_args_user) == "")]
-  
+  if (is.null(names(dot_args_user))) {
+    names(dot_args_user) <- rep("", length(dot_args_user))
+  }
+  names(dot_args_user)[names(dot_args_user) == ""] <- dot_args[
+    1:sum(names(dot_args_user) == "")
+  ]
+
   dot_args_user
 }

--- a/R/palettes.R
+++ b/R/palettes.R
@@ -13,7 +13,9 @@ pois_cols <- function(colours = NULL) {
   }
 
   chk_s3_class(colours, "character")
-  if (!all(colours %in% names(.pois_colours))) err("One or more values of colours not in .pois_colours")
+  if (!all(colours %in% names(.pois_colours))) {
+    err("One or more values of colours not in .pois_colours")
+  }
 
   .pois_colours[colours]
 }
@@ -34,7 +36,9 @@ pois_pal <- function(palette = NULL) {
 
   chk_s3_class(palette, "character")
   chk_scalar(palette)
-  if (!all(palette %in% names(.pois_palettes))) err("One or more values of palette not in .pois_palettes")
+  if (!all(palette %in% names(.pois_palettes))) {
+    err("One or more values of palette not in .pois_palettes")
+  }
 
   .pois_palettes[palette][[1]]
 }
@@ -55,28 +59,46 @@ pois_pal_disc <- function(palette = "discrete", order = NULL, reverse = FALSE) {
   chk_s3_class(palette, "character")
   chk_flag(reverse)
 
-  if (!length(palette) == 1L) err("Value of palette must be length 1")
-  if (!palette %in% names(.pois_palettes)) err("Name of palette not found in `.pois_palettes`")
+  if (!length(palette) == 1L) {
+    err("Value of palette must be length 1")
+  }
+  if (!palette %in% names(.pois_palettes)) {
+    err("Name of palette not found in `.pois_palettes`")
+  }
 
   pal_name <- palette
   palette <- pois_pal(palette)
 
-  if(!is.null(order)){
+  if (!is.null(order)) {
     chkor_vld(vld_character(order), vld_numeric(order))
 
-    if(inherits(order, "character")) {
-      if(!all(order %in% names(palette))) err("All colours in `order` must match colour names in palette `", pal_name, "`.")
-      order <-  match(order, names(palette))
+    if (inherits(order, "character")) {
+      if (!all(order %in% names(palette))) {
+        err(
+          "All colours in `order` must match colour names in palette `",
+          pal_name,
+          "`."
+        )
+      }
+      order <- match(order, names(palette))
     }
 
     order <- as.integer(order)
-    if(!all(order %in% 1:length(palette))) err("All values of order must be within the range 1 - ", length(palette), ".")
+    if (!all(order %in% 1:length(palette))) {
+      err(
+        "All values of order must be within the range 1 - ",
+        length(palette),
+        "."
+      )
+    }
 
     palette <- c(palette[order], palette)
     palette <- palette[unique(names(palette))]
   }
 
-  if (reverse) palette <- rev(palette)
+  if (reverse) {
+    palette <- rev(palette)
+  }
 
   make_palette_subsetter(palette)
 }
@@ -98,23 +120,32 @@ pois_pal_custom <- function(palette, order = NULL, reverse = FALSE) {
   chk_flag(reverse)
   chk_hex(palette)
 
-  if(!is.null(order)){
+  if (!is.null(order)) {
     chkor_vld(vld_character(order), vld_numeric(order))
 
-    if(inherits(order, "character")) {
+    if (inherits(order, "character")) {
       chk_hex(order)
-      if(!all(order %in% palette)) err("All colours in `order` must match hexadecimal codes in palette.")
-      order <-  match(order, palette)
-
+      if (!all(order %in% palette)) {
+        err("All colours in `order` must match hexadecimal codes in palette.")
+      }
+      order <- match(order, palette)
     }
 
     order <- as.integer(order)
-    if(!all(order %in% 1:length(palette))) err("All values of order must be within the range 1 - ", length(palette), ".")
+    if (!all(order %in% 1:length(palette))) {
+      err(
+        "All values of order must be within the range 1 - ",
+        length(palette),
+        "."
+      )
+    }
 
     palette <- unique(c(palette[order], palette))
   }
 
-  if (reverse) palette <- rev(palette)
+  if (reverse) {
+    palette <- rev(palette)
+  }
 
   make_palette_subsetter(palette)
 }
@@ -131,33 +162,42 @@ pois_pal_custom <- function(palette, order = NULL, reverse = FALSE) {
 #'
 #' @examples
 #' pois_pal_grad("cool", n_steps = 4)
-pois_pal_grad <- function(palette = "cool",
-                          reverse = FALSE,
-                          n_steps = 256,
-                          n_col = getOption("poispalette.n_col", NULL)){
+pois_pal_grad <- function(
+  palette = "cool",
+  reverse = FALSE,
+  n_steps = 256,
+  n_col = getOption("poispalette.n_col", NULL)
+) {
   chk_whole_number(n_steps)
   chk_gt(n_steps, 1)
   chk_s3_class(palette, "character")
   chk_flag(reverse)
 
-  if(length(palette) == 1L && !vld_hex(palette)) {
-    if (!palette %in% names(.pois_palettes)) err("Name of palette not found in `.pois_palettes`")
+  if (length(palette) == 1L && !vld_hex(palette)) {
+    if (!palette %in% names(.pois_palettes)) {
+      err("Name of palette not found in `.pois_palettes`")
+    }
     palette <- pois_pal(palette)
   } else {
     chk_hex(palette)
   }
 
-  if(!is.null(n_col)) {
+  if (!is.null(n_col)) {
     chk_whole_number(n_col)
-    if(n_col < 2) err("Argument `n_col` must be 2 or greater.")
-    if(n_col > length(palette)) err("Argument `n_col` is greater than number of colours in palette.")
-
-    palette <- palette[1:n_col]
+    if (n_col < 2) {
+      err("Argument `n_col` must be 2 or greater.")
+    }
+    if (n_col > length(palette)) {
+      err("Argument `n_col` is greater than number of colours in palette.")
     }
 
-  if (reverse) palette <- rev(palette)
+    palette <- palette[1:n_col]
+  }
+
+  if (reverse) {
+    palette <- rev(palette)
+  }
 
   palette_interpolator <- scales::as_continuous_pal(palette)
-  palette_interpolator(seq(0, 1, by = (1/(n_steps - 1))))
-
+  palette_interpolator(seq(0, 1, by = (1 / (n_steps - 1))))
 }

--- a/R/scales.R
+++ b/R/scales.R
@@ -12,26 +12,29 @@
 #'   geom_point() +
 #'   scale_colour_disc_poisson()
 scale_colour_disc_poisson <- function(
-    ...,
-    palette = getOption("poispalette.colours", "discrete"),
-    order = NULL,
-    reverse = FALSE
+  ...,
+  palette = getOption("poispalette.colours", "discrete"),
+  order = NULL,
+  reverse = FALSE
 ) {
-
-  if(length(palette) == 1L && !all(vld_hex(palette))){
-    pal <- pois_pal_disc(palette = palette, reverse = reverse, order = order)    
+  if (length(palette) == 1L && !all(vld_hex(palette))) {
+    pal <- pois_pal_disc(palette = palette, reverse = reverse, order = order)
   } else {
     pal <- pois_pal_custom(palette = palette, reverse = reverse)
   }
-  
+
   dot_args_user <- assign_dot_args(
-    list(...), ggplot2::discrete_scale, c("aesthetics", "palette", "na.value")
+    list(...),
+    ggplot2::discrete_scale,
+    c("aesthetics", "palette", "na.value")
   )
-  
+
   rlang::inject(ggplot2::discrete_scale(
-    aesthetics = "colour", palette = pal, na.value = .na_colour, !!!dot_args_user 
+    aesthetics = "colour",
+    palette = pal,
+    na.value = .na_colour,
+    !!!dot_args_user
   ))
-  
 }
 
 #' discrete fill scale constructor for poisson colours
@@ -48,30 +51,34 @@ scale_colour_disc_poisson <- function(
 #'   geom_point(shape = 21) +
 #'   scale_fill_disc_poisson()
 scale_fill_disc_poisson <- function(
-    ...,
-    palette = getOption("poispalette.colours", "discrete"),
-    order = NULL,
-    reverse = FALSE
-    ){
-
-  if(length(palette) == 1L && !all(vld_hex(palette))){
-    pal <- pois_pal_disc(palette = palette, reverse = reverse, order = order)    
+  ...,
+  palette = getOption("poispalette.colours", "discrete"),
+  order = NULL,
+  reverse = FALSE
+) {
+  if (length(palette) == 1L && !all(vld_hex(palette))) {
+    pal <- pois_pal_disc(palette = palette, reverse = reverse, order = order)
   } else {
     pal <- pois_pal_custom(palette = palette, reverse = reverse)
   }
-  
+
   dot_args_user <- assign_dot_args(
-    list(...), ggplot2::discrete_scale, c("aesthetics", "palette", "na.value")
+    list(...),
+    ggplot2::discrete_scale,
+    c("aesthetics", "palette", "na.value")
   )
-  
+
   rlang::inject(ggplot2::discrete_scale(
-    aesthetics = "fill", palette = pal, na.value = .na_colour, !!!dot_args_user
-    ))
+    aesthetics = "fill",
+    palette = pal,
+    na.value = .na_colour,
+    !!!dot_args_user
+  ))
 }
 
 #' gradient colour scale constructor for poisson colours
 #'
-#' @param palette Character name of palette in pois_palettes, or selection 
+#' @param palette Character name of palette in pois_palettes, or selection
 #' of colour names from pois_cols
 #' @param reverse Boolean indicating whether the palette should be reversed
 #' @param n_steps Number of steps in gradient
@@ -85,27 +92,35 @@ scale_fill_disc_poisson <- function(
 #'   geom_point() +
 #'   scale_colour_grad_poisson(palette = "cool")
 scale_colour_grad_poisson <- function(
-    ...,
-    palette = getOption("poispalette.gradient", "cool"),
-    reverse = FALSE,
-    n_steps = 256,
-    n_col = getOption("poispalette.n_col", NULL)
-    ){
-
-  pal <- pois_pal_grad(palette = palette, reverse = reverse, n_steps = n_steps, n_col = n_col)
-  
-  dot_args_user <- assign_dot_args(
-    list(...), ggplot2::scale_color_gradientn, c("colours", "na.value", "space")
+  ...,
+  palette = getOption("poispalette.gradient", "cool"),
+  reverse = FALSE,
+  n_steps = 256,
+  n_col = getOption("poispalette.n_col", NULL)
+) {
+  pal <- pois_pal_grad(
+    palette = palette,
+    reverse = reverse,
+    n_steps = n_steps,
+    n_col = n_col
   )
-  
+
+  dot_args_user <- assign_dot_args(
+    list(...),
+    ggplot2::scale_color_gradientn,
+    c("colours", "na.value", "space")
+  )
+
   rlang::inject(ggplot2::scale_color_gradientn(
-    colours = pal, na.value = .na_colour, !!!dot_args_user
-    ))
+    colours = pal,
+    na.value = .na_colour,
+    !!!dot_args_user
+  ))
 }
 
 #' Gradient fill scale constructor for poisson colours
 #'
-#' @param palette Character name of palette in pois_palettes, or selection 
+#' @param palette Character name of palette in pois_palettes, or selection
 #' of colour names from pois_cols
 #' @param reverse Boolean indicating whether the palette should be reversed
 #' @param n_steps Number of steps in gradient
@@ -119,22 +134,30 @@ scale_colour_grad_poisson <- function(
 #'   geom_point(shape = 21) +
 #'   scale_fill_grad_poisson(palette = "cool")
 scale_fill_grad_poisson <- function(
-    ...,
-    palette = getOption("poispalette.gradient", "cool"),
-    reverse = FALSE,
-    n_steps = 256,
-    n_col = getOption("poispalette.n_col", NULL)
-    ){
-
-  pal <- pois_pal_grad(palette = palette, reverse = reverse, n_steps = n_steps, n_col = n_col)
-  
-  dot_args_user <- assign_dot_args(
-    list(...), ggplot2::scale_fill_gradientn, c("colours", "na.value")
+  ...,
+  palette = getOption("poispalette.gradient", "cool"),
+  reverse = FALSE,
+  n_steps = 256,
+  n_col = getOption("poispalette.n_col", NULL)
+) {
+  pal <- pois_pal_grad(
+    palette = palette,
+    reverse = reverse,
+    n_steps = n_steps,
+    n_col = n_col
   )
-  
+
+  dot_args_user <- assign_dot_args(
+    list(...),
+    ggplot2::scale_fill_gradientn,
+    c("colours", "na.value")
+  )
+
   rlang::inject(ggplot2::scale_fill_gradientn(
-    colours = pal, na.value = .na_colour, !!!dot_args_user
-    ))
+    colours = pal,
+    na.value = .na_colour,
+    !!!dot_args_user
+  ))
 }
 
 #' @export

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/scripts/build.R
+++ b/scripts/build.R
@@ -1,11 +1,37 @@
-roxygen2md::roxygen2md()
-styler::style_pkg(filetype = c("R", "Rmd"))
-lintr::lint_package()
+styler::style_pkg(
+  scope = "line_breaks",
+  filetype = c("R", "Rmd")
+)
 
-devtools::test()
+lintr::lint_package(
+  linters = lintr::linters_with_defaults(
+    line_length_linter = lintr::line_length_linter(1000),
+    object_name_linter = lintr::object_name_linter(regexes = ".*")
+  )
+)
+
+roxygen2md::roxygen2md()
 devtools::document()
 
-rmarkdown::render("README.Rmd", output_format = "md_document")
-pkgdown::build_site()
+devtools::build_readme()
 
+# Note: Only use pkgdown to build a documentation website for public facing packages
+pkgdown::build_home()
+pkgdown::build_reference()
+pkgdown::build_site()
+browseURL("docs/index.html")
+
+devtools::test()
 devtools::check()
+
+# Test files that have less then 100% coverage
+covr:::tally_coverage(covr::package_coverage()) |>
+  dplyr::summarize(
+    percent_coverage = mean(value > 0) * 100,
+    .by = filename
+  ) |>
+  dplyr::filter(percent_coverage < 100) |>
+  dplyr::arrange(percent_coverage)
+
+# Report for all test files
+covr::report(covr::package_coverage())

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -10,6 +10,6 @@ save_png <- function(x, width = 400, height = 400) {
   grDevices::png(path, width = width, height = height)
   on.exit(grDevices::dev.off())
   print(x)
-  
+
   path
 }

--- a/tests/testthat/test-internal.R
+++ b/tests/testthat/test-internal.R
@@ -10,15 +10,28 @@ test_that("chk_hex works", {
 })
 
 test_that("handling of ... args", {
-  
   expect_identical(
-    get_formals(ggplot2::discrete_scale, negate = "super"), 
-    c("aesthetics", "palette", "name", "breaks", "minor_breaks", 
-"labels", "limits", "expand", "na.translate", "na.value", "drop", 
-"guide", "position", "fallback.palette", "call")
+    get_formals(ggplot2::discrete_scale, negate = "super"),
+    c(
+      "aesthetics",
+      "palette",
+      "name",
+      "breaks",
+      "minor_breaks",
+      "labels",
+      "limits",
+      "expand",
+      "na.translate",
+      "na.value",
+      "drop",
+      "guide",
+      "position",
+      "fallback.palette",
+      "call"
     )
+  )
   expect_error(get_formals(1, negate = "super"), "`fun` must be a function.")
-  
+
   expect_identical(
     assign_dot_args(
       list("name", labels = c("a", "b"), 1:2),
@@ -27,7 +40,7 @@ test_that("handling of ... args", {
     ),
     list(name = "name", labels = c("a", "b"), breaks = 1:2)
   )
-  
+
   expect_error(
     assign_dot_args(
       c("name"),
@@ -36,7 +49,7 @@ test_that("handling of ... args", {
     ),
     "`dot_args_user` must be a list."
   )
-  
+
   expect_error(
     assign_dot_args(
       list("name"),
@@ -45,5 +58,4 @@ test_that("handling of ... args", {
     ),
     "`args_negate` must be atomic."
   )
-  
 })

--- a/tests/testthat/test-palettes.R
+++ b/tests/testthat/test-palettes.R
@@ -1,31 +1,35 @@
 test_that("pois_cols works", {
   expect_identical(pois_cols(), poispalette:::.pois_colours)
-  
-  expect_identical(pois_cols(c("black", "blue")), poispalette:::.pois_colours[1:2])
-  
-  expect_error(pois_cols(colours = "not a colour"),
-               "One or more values of colours not in .pois_colours")
+
+  expect_identical(
+    pois_cols(c("black", "blue")),
+    poispalette:::.pois_colours[1:2]
+  )
+
+  expect_error(
+    pois_cols(colours = "not a colour"),
+    "One or more values of colours not in .pois_colours"
+  )
 })
 
 test_that("pois_pal works", {
   expect_identical(pois_pal(), pois_cols()[1:10])
-  
+
   expect_error(
     pois_pal("not a pal"),
     "One or more values of palette not in .pois_palettes."
-    )
+  )
 })
 
 test_that("chk_hex works", {
-  
   good <- c("#112233", "#FFEEDD")
   expect_identical(chk_hex(good), good)
-  
+
   bad <- c("112233", "#FFEEDDD", "#FFEEDDX", "#112233")
   expect_error(
     chk_hex(bad),
     "Invalid hex codes detected: 112233, #FFEEDDD, #FFEEDDX."
-    )
+  )
 })
 
 test_that("pois_pal_disc works", {
@@ -39,38 +43,38 @@ test_that("pois_pal_disc works", {
   expect_identical(
     palette,
     pois_cols()[1:10] |> as.vector() %>% rev()
-    )
-  
+  )
+
   expect_error(
     pois_pal_disc(palette = "not a palette"),
     "Name of palette not found in `.pois_palettes`"
-    )
+  )
   expect_error(
     pois_pal_disc(palette = c("too", "many")),
     "Value of palette must be length 1"
-    )
+  )
 })
 
 test_that("pois_pal_grad works", {
   expect_error(
     pois_pal_grad(palette = "not a palette"),
     "Name of palette not found in `.pois_palettes`"
-    )
+  )
   expect_error(
     pois_pal_grad(palette = c("not", "colours")),
     "Invalid hex codes detected: not, colours."
-    )
-  
+  )
+
   expect_error(
     pois_pal_grad(palette = "cool", n_col = 10),
     "Argument `n_col` is greater than number of colours in palette."
   )
-  
+
   expect_error(
     pois_pal_grad(palette = "cool", n_col = 1),
     "Argument `n_col` must be 2 or greater."
   )
-  
+
   expect_identical(
     pois_pal_grad("cool", n_steps = 4),
     c("#8EE7E6", "#00B4D8", "#0077B6", "#03045E")
@@ -87,7 +91,6 @@ test_that("pois_pal_grad works", {
     pois_pal_grad("cool", n_steps = 2.5),
     "`n_steps` must be a whole number"
   )
-
 })
 
 test_that("pois_pal_custom works", {
@@ -96,37 +99,40 @@ test_that("pois_pal_custom works", {
     palette,
     c("#1E6091", "#D9ED92", "#99D98C")
   )
-  
-  palette <- pois_pal_custom(c("#1E6091", "#D9ED92", "#99D98C"), reverse = TRUE)(3)
+
+  palette <- pois_pal_custom(
+    c("#1E6091", "#D9ED92", "#99D98C"),
+    reverse = TRUE
+  )(3)
   expect_identical(
     palette,
     c("#99D98C", "#D9ED92", "#1E6091")
   )
-  
 })
 
 test_that("test that 'order' arg in palette functions works", {
- 
   palette <- pois_pal_disc(order = c("red", "blue", "yellow"))(4)
   expect_identical(
     palette,
     pois_cols()[c("red", "blue", "yellow", "black")] %>% as.character()
-    )
-  
-  
+  )
+
   palette <- pois_pal_disc(order = c(3, 2, 4))(4)
   expect_identical(
     palette,
     pois_cols()[c("red", "blue", "yellow", "black")] %>% as.character()
   )
-  
+
   custom_cols <- c("#03045e", "#04055f", "#04065f", "#050760", "#050861")
-  palette <- pois_pal_custom(custom_cols, order = c("#04065f", "#050760", "#050861"))(5)
+  palette <- pois_pal_custom(
+    custom_cols,
+    order = c("#04065f", "#050760", "#050861")
+  )(5)
   expect_identical(
     palette,
     c("#04065f", "#050760", "#050861", "#03045e", "#04055f")
   )
-  
+
   expect_error(
     pois_pal_disc(order = c("bed", "blue", "yellow")),
     "All colours in `order` must match colour names in palette `discrete`."
@@ -136,16 +142,14 @@ test_that("test that 'order' arg in palette functions works", {
     pois_pal_disc(order = c(TRUE)),
     "At least one of the following conditions must be met:"
   )
-  
+
   expect_error(
     pois_pal_disc(order = c(TRUE)),
     "At least one of the following conditions must be met:"
   )
-  
+
   expect_error(
     pois_pal_disc(order = 1:11)(11),
     "All values of order must be within the range 1 - 10."
   )
-  
 })
-

--- a/tests/testthat/test-scales-snapshot.R
+++ b/tests/testthat/test-scales-snapshot.R
@@ -1,5 +1,8 @@
 test_that("scale functions work with plots", {
-  gp <- ggplot2::ggplot(poispalette::points, ggplot2::aes(x = RandomX, y = RandomY)) +
+  gp <- ggplot2::ggplot(
+    poispalette::points,
+    ggplot2::aes(x = RandomX, y = RandomY)
+  ) +
     ggplot2::geom_point(ggplot2::aes(colour = ID), size = 2) +
     scale_colour_disc_poisson()
 
@@ -17,7 +20,10 @@ test_that("scale functions correctly display NA data values", {
   points_with_na_id <- poispalette::points[1:5, ]
   points_with_na_id$ID[5] <- NA
 
-  gp <- ggplot2::ggplot(points_with_na_id, ggplot2::aes(x = RandomX, y = RandomY)) +
+  gp <- ggplot2::ggplot(
+    points_with_na_id,
+    ggplot2::aes(x = RandomX, y = RandomY)
+  ) +
     ggplot2::geom_col(ggplot2::aes(colour = ID, fill = ID)) +
     scale_colour_disc_poisson() +
     scale_fill_disc_poisson()
@@ -38,31 +44,38 @@ test_that("scale functions correctly display NA data values", {
 
 
 test_that("scale functions correctly pass ... args", {
-
-points <- poispalette::points
-points$ID <- factor(points$ID)
-points <- points[points$ID != "B", ]
+  points <- poispalette::points
+  points$ID <- factor(points$ID)
+  points <- points[points$ID != "B", ]
 
   gp <- ggplot2::ggplot(points, ggplot2::aes(x = RandomX, y = RandomY)) +
     ggplot2::geom_point(ggplot2::aes(colour = ID), size = 2) +
     scale_colour_disc_poisson(
-      "scale name", c("A", "B", "C"), limits = c("A", "B", "C", "D", "E"), c("a", "b", "c") # na.translate and drop not tested
-      )
-  
+      "scale name",
+      c("A", "B", "C"),
+      limits = c("A", "B", "C", "D", "E"),
+      c("a", "b", "c") # na.translate and drop not tested
+    )
+
   local_edition(3)
   expect_snapshot_plot(gp, "disc_pals_with_dot_args")
-  
+
   gp <- ggplot2::ggplot(poispalette::points, ggplot2::aes(x = X, y = Y)) +
     ggplot2::geom_point(ggplot2::aes(colour = RandomX), size = 2) +
     scale_colour_grad_poisson(
-      palette = c("#FF0000", "#00FF00"), "scale name", guide = "legend"
-      )
-  
+      palette = c("#FF0000", "#00FF00"),
+      "scale name",
+      guide = "legend"
+    )
+
   expect_snapshot_plot(gp, "grad_pals_with_dot_args")
 })
 
 
-if(FALSE) {
-  testthat::test_file(file.path(getwd(),"tests/testthat/test-scales-snapshot.R"))
+if (FALSE) {
+  testthat::test_file(file.path(
+    getwd(),
+    "tests/testthat/test-scales-snapshot.R"
+  ))
   testthat::snapshot_review('scales-snapshot/')
 }

--- a/tests/testthat/test-scales.R
+++ b/tests/testthat/test-scales.R
@@ -1,26 +1,25 @@
-
 test_that("scale functions produce objects", {
   scale <- scale_colour_disc_poisson()
   expect_identical(class(scale), c("ScaleDiscrete", "Scale", "ggproto", "gg"))
-  
+
   scale <- scale_fill_disc_poisson()
   expect_identical(class(scale), c("ScaleDiscrete", "Scale", "ggproto", "gg"))
-  
+
   scale <- scale_colour_grad_poisson(palette = "cool")
   expect_identical(class(scale), c("ScaleContinuous", "Scale", "ggproto", "gg"))
-  
+
   scale <- scale_fill_grad_poisson(palette = "hot")
   expect_identical(class(scale), c("ScaleContinuous", "Scale", "ggproto", "gg"))
-  
+
   scale <- scale_colour_disc_poisson(palette = "#000000")
   expect_identical(class(scale), c("ScaleDiscrete", "Scale", "ggproto", "gg"))
-  
+
   scale <- scale_fill_disc_poisson(palette = "#000000")
   expect_identical(class(scale), c("ScaleDiscrete", "Scale", "ggproto", "gg"))
-  
+
   scale <- scale_colour_grad_poisson(palette = c("#000000", "#000000"))
   expect_identical(class(scale), c("ScaleContinuous", "Scale", "ggproto", "gg"))
-  
+
   scale <- scale_fill_grad_poisson(palette = c("#000000", "#000000"))
   expect_identical(class(scale), c("ScaleContinuous", "Scale", "ggproto", "gg"))
 })


### PR DESCRIPTION
Closes #87

Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)